### PR TITLE
Give tvg-id priority.

### DIFF
--- a/provider_video_m3u/lib/channels.py
+++ b/provider_video_m3u/lib/channels.py
@@ -105,15 +105,15 @@ class Channels(PluginChannels):
                 else:
                     ch_number = self.set_channel_num(ch_number)
 
-                if 'channel-id' in seg.additional_props and \
+                if 'tvg-id' in seg.additional_props and \
+                        len(seg.additional_props['tvg-id']) != 0:
+                    ch_id = seg.additional_props['tvg-id']
+                elif 'channel-id' in seg.additional_props and \
                         len(seg.additional_props['channel-id']) != 0:
                     ch_id = seg.additional_props['channel-id']
                 elif 'channelID' in seg.additional_props and \
                         len(seg.additional_props['channelID']) != 0:
                     ch_id = seg.additional_props['channelID']
-                elif 'tvg-id' in seg.additional_props and \
-                        len(seg.additional_props['tvg-id']) != 0:
-                    ch_id = seg.additional_props['tvg-id']
                 elif ch_number is not None:
                     ch_id = str(ch_number)
                 else:


### PR DESCRIPTION
Give tvg-id priority to fix issues where xml's channel id doesn't match the m3u.